### PR TITLE
Fix encoding error with Ruby 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ group :development do
   gem "rspec"
 end
 
+gem 'rest-client'
 # Specify your gem's dependencies in socket.io-client.gemspec
 gemspec

--- a/lib/web_socket.rb
+++ b/lib/web_socket.rb
@@ -181,7 +181,7 @@ class WebSocket
       case @web_socket_version
         
         when "hixie-75", "hixie-76"
-          packet = gets("\xff")
+          packet = gets(force_encoding("\xff", "ASCII-8BIT"))
           return nil if !packet
           if packet =~ /\A\x00(.*)\xff\z/nm
             return force_encoding($1, "UTF-8")


### PR DESCRIPTION
Fix the following error that occurs when running `socketio-client` with Ruby 2.0 or higher.

``` bash
/Users/yasulab/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/socketio-client-0.0.3/lib/web_socket.rb:336:in `gets': encoding mismatch: ASCII-8BIT IO with UTF-8 RS (ArgumentError)
    from /Users/yasulab/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/socketio-client-0.0.3/lib/web_socket.rb:336:in `gets'
    from /Users/yasulab/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/socketio-client-0.0.3/lib/web_socket.rb:184:in `receive'
    from /Users/yasulab/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/socketio-client-0.0.3/lib/SocketIO.rb:67:in `block in start_recieve_loop'
```
